### PR TITLE
Added pointer to sub simulator controls documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ At this point, you can start a roscore and try running the SubjuGator simulator 
     roscore &
     rosrun subsim sim
 
-The simulator's user interface isn't currently documented (though that should change very soon), so you'll have to either try pressing keys or look at the source. One hint: Pressing TAB enables FPS camera mode.
+The simulator's user interface is documented in the subsim's README.md file, to get there:
 
+    roscd subsim
+    nano readme.md
 
 Updating uf-mil repositories
 ----------------------------


### PR DESCRIPTION
Previously, the readme only stated that the sub simulator may be documented at a future time, I changed it to directions to the readme located in the subsim package (package may not be the correct term here)
